### PR TITLE
Add Docker Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.3-apache-bookworm
+WORKDIR /var/www/html
+
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+COPY index.php public/index.php
+
+RUN apt-get update && \
+        apt-get -y install snmp libsnmp-dev
+
+RUN docker-php-ext-install snmp
+
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ Make sure you have [Docker Engine installed](https://docs.docker.com/engine/inst
 ```shell
 git clone https://github.com/disisto/apc-switched-rack-pdu-control-panel.git
 cd apc-switched-rack-pdu-control-panel
+cp config.example.php config.php
+# Update `config.php` with appropriate values for your PDU(s)
 docker compose up -d
 ```
 
 Browse to http://localhost:8080, and the control panel should be displayed.
 
 ## Quick Install
-No&nbsp;🚀&nbsp;science: Upload a single PHP file on a Webserver, enter the PDU IP address and the SNMPv3 access data with an editor and the script is ready for use.
+No&nbsp;🚀&nbsp;science: Upload two PHP files on a Webserver. Enter the PDU IP address and the SNMPv3 access data with an editor in `config.php`, and the script is ready for use.
 
 ---
 This project is not affiliated with <a href="https://www.apc.com/">APC by Schneider Electric</a>.<br>

--- a/README.md
+++ b/README.md
@@ -33,10 +33,23 @@ A PHP based Control Panel to control multiple APC Switched Rack PDUs via SNMPv3.
 + Web server with <a href="https://github.com/php/php-src">PHP</a>
 + PHP module: `php-snmp`
 + APC Switched Rack PDU(s) with enabled SNMPv3 
+  * Tested with APC Switched Rack PDU <a href="https://www.apc.com/us/en/product/AP7901/rack-pdu-switched-1u-20a-120v-8520/">AP7901</a> on EOL firmware `v3.9.3`
   * Tested with APC Switched Rack PDU <a href="https://www.apc.com/shop/my/en/products/Rack-PDU-Switched-1U-12A-208V-10A-230V-8-C13/P-AP7920">AP7920</a> and <a href="https://www.apc.com/shop/my/en/products/Rack-PDU-Switched-1U-12A-208V-10A-230V-8-C13/P-AP7921">AP7921</a> on EOL firmware `v3.9.2`
   * Tested with APC Switched Rack PDU <a href="https://www.apc.com/shop/my/en/products/Rack-PDU-Switched-1U-12A-208V-10A-230V-8-C13/P-AP7920B">AP7920B</a> on latest firmware `v6.5.6`
 
 ---
+
+## Run with Docker
+
+Make sure you have [Docker Engine installed](https://docs.docker.com/engine/install/)
+
+```shell
+git clone https://github.com/disisto/apc-switched-rack-pdu-control-panel.git
+cd apc-switched-rack-pdu-control-panel
+docker compose up -d
+```
+
+Browse to http://localhost:8080, and the control panel should be displayed.
 
 ## Quick Install
 No&nbsp;🚀&nbsp;science: Upload a single PHP file on a Webserver, enter the PDU IP address and the SNMPv3 access data with an editor and the script is ready for use.

--- a/config.example.php
+++ b/config.example.php
@@ -1,0 +1,23 @@
+<?php
+return [
+    [
+        'active' => false,              // Toggle Switch             :: Switch on (true) or switch off (false) to stop monitoring the PDU.
+        'ipAddress' => '',              // IP address                :: Enter the IP address of the PDU
+        'userProfile' => '',            // User Name                 :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> User Name | NOTE: The SNMP user name can contain up to 32 characters in length and include any combination of alphanumeric characters (uppercase letters, lowercase letters, and numbers). ⚠️  Spaces not allowed.
+        'authenticationPassphrase' => '',         // Authentication Passphrase :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Authentication Passphrase | NOTE: The password must be 15-32 ASCII characters long. ⚠️ Special characters not allowed.
+        'authenticationProtocol' => '',           // Authentication Protocol   :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Authentication Protocol
+        'privacyPassphrase' => '',      // Privacy Passphrase        :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Privacy Passphrase | NOTE: The password must be 15-32 ASCII characters long. ⚠️ Special characters not allowed.
+        'privacyProtocol' => '',        // Privacy Protocol          :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Privacy Protocol
+        'securityLevel' => ''           // Security Level            :: Set desired security level: noAuthNoPriv | authNoPriv | authPriv | More detail: https://www.php.net/manual/en/function.snmp3-get.php
+    ],
+    [
+        'active' => false,              // Toggle Switch             :: Switch on (true) or switch off (false) to stop monitoring the PDU.
+        'ipAddress' => '',              // IP address                :: Enter the IP address of the PDU
+        'userProfile' => '',            // User Name                 :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> User Name | NOTE: The SNMP user name can contain up to 32 characters in length and include any combination of alphanumeric characters (uppercase letters, lowercase letters, and numbers). ⚠️  Spaces not allowed.
+        'authenticationPassphrase' => '',         // Authentication Passphrase :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Authentication Passphrase | NOTE: The password must be 15-32 ASCII characters long. ⚠️ Special characters not allowed.
+        'authenticationProtocol' => '',           // Authentication Protocol   :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Authentication Protocol
+        'privacyPassphrase' => '',      // Privacy Passphrase        :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Privacy Passphrase | NOTE: The password must be 15-32 ASCII characters long. ⚠️ Special characters not allowed.
+        'privacyProtocol' => '',        // Privacy Protocol          :: Administration -> Network -> SNMPv3: user profiles -> choose profile from list -> Privacy Protocol
+        'securityLevel' => ''           // Security Level            :: Set desired security level: noAuthNoPriv | authNoPriv | authPriv | More detail: https://www.php.net/manual/en/function.snmp3-get.php
+    ]
+];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,7 @@ version: '3.9'
 services:
   web:
     build: "./"
+    volumes:
+      - ./config.php:/var/www/html/config.php
     ports:
       - '8080:80'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.9'
+
+services:
+  web:
+    build: "./"
+    ports:
+      - '8080:80'


### PR DESCRIPTION
This PR adds the ability to run this (awesome!) tool in Docker, which saves the effort of having to manually install PHP, php-snmp, net-snmp-utils, and your web server daemon of choice.

The most notable change is the re-location of the PDU configuration from `index.php` into a standalone `config.php` file. Since `index.php` gets copied into the image at build time, with the configuration values inside that file it's not possible to make any changes without rebuilding the image. Having `config.php` mounted as a volume (via `docker compose`) allows it to be updated as needed while `index.php` remains static in the image. I've done my best to update `README.md` accordingly for this.